### PR TITLE
Add Openshift Docker Registry as insecure registry

### DIFF
--- a/ike/orb.yml
+++ b/ike/orb.yml
@@ -9,7 +9,7 @@ commands:
           name: "Configuring docker daemon to use insecure registries"
           command: |
             json=`mktemp`
-            echo '{ "insecure-registries": [ "172.30.0.0/16", "registry.access.redhat.com" ] }' > ${json}
+            echo '{ "insecure-registries": [ "172.30.0.0/16", "registry.access.redhat.com", "docker-registry-default.127.0.0.1.nip.io:80" ] }' > ${json}
             sudo mv ${json} /etc/docker/daemon.json
             sudo service docker restart
             echo "Configured Docker daemon with insecure-registry"


### PR DESCRIPTION
Allow pushing directly to an Openshift registry exposed on a local Openshift install.